### PR TITLE
Update deps.

### DIFF
--- a/gradle-mkdeb.sh
+++ b/gradle-mkdeb.sh
@@ -25,7 +25,7 @@ fpm_args=(
   --name "gradle-${VERSION}"
   --version "${VERSION}"
   --iteration "${ITERATION}"
-  --depends "java-runtime | default-jre-headless"
+  --depends "java2-runtime | java-runtime | default-jre-headless"
   --architecture all
   --maintainer "Benjamin Staffin <benley@gmail.com>"
   --license "Apache-2.0"


### PR DESCRIPTION
This change accounts for recent changes in openjdk deb packaging which
removed the deprecated `java-runtime` provides leaving only
`java2-runtime`. See the commit here:
http://bazaar.launchpad.net/~openjdk/openjdk/openjdk8/revision/672/debian/control
